### PR TITLE
Fix metadata 

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "id": "oxide",
   "version": "${mod_version}",
-  "name": "Template Mod",
-  "description": "Template Mod Description",
+  "name": "${mod_name}",
+  "description": "${mod_description}",
   "authors": [
     "Ordana"
   ],
@@ -24,7 +24,7 @@
     "oxide-common.mixins.json"
   ],
   "depends": {
-    "fabric": "*",
+    "fabric-api": "*",
     "minecraft": "1.21.1",
     "moonlight": ">=1.21-2.17.34"
   }

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -6,14 +6,14 @@ loaderVersion="[4,)"
 license="LGPLv3"
 
 [[mods]]
-    modId="oxide"
-    version = "${version}"
-    displayName="Oxide"
+    modId="${mod_id}"
+    version = "${mod_version}"
+    displayName="${mod_name}"
     logoFile="icon.png"
     credits="Ordana"
     authors="Ordana, Keyberries"
     itemIcon="oxide:template"
-    description='''Template Mod Description'''
+    description='''${mod_description}'''
 
 [[dependencies.oxide]]
     modId="neoforge"


### PR DESCRIPTION
`fabric.mod.json` and `neoforge.mods.toml` were missing info about the mod, NeoForge in particular was causing builds to fail. I've also switched `fabric` to `fabric-api`, as that has been recommended since 1.19.