### PR TITLE
Fix crashes when rusting Iron with a Wet Sponge

### DIFF
--- a/common/src/main/java/com/ordana/oxide/blocks/rusty/Rustable.java
+++ b/common/src/main/java/com/ordana/oxide/blocks/rusty/Rustable.java
@@ -425,11 +425,13 @@ public interface Rustable extends ChangeOverTimeBlock<Rustable.RustLevel> {
 
             if (rusted.isPresent()) {
                 level.playSound(player, pos, SoundEvents.AMBIENT_UNDERWATER_ENTER, SoundSource.BLOCKS, 1.0f, 1.0f);
-                ParticleUtil.spawnParticlesOnBlockFaces(level, pos, ParticleTypes.SPLASH, UniformInt.of(3, 5), -0.05f, 0.05f, false);
                 if (player instanceof ServerPlayer serverPlayer) {
                     player.awardStat(Stats.ITEM_USED.get(item));
                     CriteriaTriggers.ITEM_USED_ON_BLOCK.trigger(serverPlayer, pos, stack);
                     level.setBlockAndUpdate(pos, rusted.get());
+                }
+                else {
+                    ParticleUtil.spawnParticlesOnBlockFaces(level, pos, ParticleTypes.SPLASH, UniformInt.of(3, 5), -0.05f, 0.05f, false);
                 }
                 return ItemInteractionResult.sidedSuccess(level.isClientSide);
             }


### PR DESCRIPTION
Currently, it tries to load particles on the dedicated server, where the class does not exist. I've moved this to an else block on the existing server check, which works fine in my devenv server and in singleplayer.